### PR TITLE
Removes ampersand and replaces with try

### DIFF
--- a/lib/cartowrap/http_service.rb
+++ b/lib/cartowrap/http_service.rb
@@ -6,7 +6,7 @@ module Cartowrap
     class << self
     end
     def self.make_request(options, credentials={})
-      http_method = options.http_method&.to_sym || :get
+      http_method = options.http_method.try(:to_sym) || :get
       account = credentials["account"]
       endpoint = Endpoint.new(options, credentials).get
       con = Faraday.new(:url => "https://#{account}.cartodb.com") do |faraday|


### PR DESCRIPTION
If I understand it correctly the idea is that if there's no defined http_method inside options it will use :get as the default. `&.to_sym` was crashing on my application, and I don't recognize that syntax, so I'm assuming it was just a typo. This is a fix to that issue and uses try to avoid calling to_sym on nil and getting an exception.

What do you think @CV-Gate?