### PR TITLE
Adds method post_query to api.rb

### DIFF
--- a/lib/cartowrap/api.rb
+++ b/lib/cartowrap/api.rb
@@ -20,6 +20,16 @@ module Cartowrap
       result
     end
 
+    def post_query(query)
+      options.http_method = "post"
+      options.query_string = false
+      options.endpoint = "sql_post"
+      options.marshal_dump≈ {}
+      options.marshal_dump[:q]= query
+      result = make_call(options)
+      result
+    end
+
     def get_synchronizations
       options.endpoint = "import"
       options.query_string = false

--- a/lib/cartowrap/http_service/endpoint.rb
+++ b/lib/cartowrap/http_service/endpoint.rb
@@ -24,6 +24,8 @@ module Cartowrap
         case api
         when "sql"
           string += "/api/v2/sql/?q=#{query}"
+        when "sql_post"
+          string += "/api/v2/sql/"
         when "import"
           string += "/api/v1/synchronizations/"
           string += "?#{options.query}" if options.query_string && options.query

--- a/spec/cases/api_spec.rb
+++ b/spec/cases/api_spec.rb
@@ -7,6 +7,10 @@ describe "Cartowrap::API" do
     expect(Cartowrap).to receive(:make_request).and_return(Cartowrap::HTTPService::Response.new(200, "", ""))
     @service.send_query('anything')
   end
+  it "makes post query requests" do
+    expect(Cartowrap).to receive(:make_request).and_return(Cartowrap::HTTPService::Response.new(200, "", ""))
+    @service.post_query('anything')
+  end
   it "gets synchronizations index" do
     expect(Cartowrap).to receive(:make_request).and_return(Cartowrap::HTTPService::Response.new(200, "", ""))
     @service.get_synchronizations


### PR DESCRIPTION
This will allow sending queries to CartoDB as post request, allowing large inserts of data into tables for instance (which would clash with URI length limitations).