### PR TITLE
Sets a required ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3.1
 before_install: gem install bundler -v 1.11.2

--- a/cartowrap.gemspec
+++ b/cartowrap.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.description = "Provides a common interface for some CartoDB functions."
   s.license     = "MIT"
 
+  s.required_ruby_version = ">= 2.3.1"
+
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   s.require_paths  = ["lib"]
 


### PR DESCRIPTION
As we are using some syntax that is only available with Ruby >=2.3.1, see this thread: https://github.com/Vizzuality/cartowrap/pull/1
