### PR TITLE
Adds support for self installed carto instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ require 'cartowrap'
 Cartowrap.configure do |config|
   config.account = your_cartodb_account
   config.api_key = your_api_key
+  config.carto_url = your_carto_url # only if you have a custom Carto installation in your own server
 end
 
 # Any other place in your code 

--- a/lib/cartowrap/http_service.rb
+++ b/lib/cartowrap/http_service.rb
@@ -7,9 +7,10 @@ module Cartowrap
     end
     def self.make_request(options, credentials={})
       http_method = options.http_method&.to_sym || :get
-      account = credentials["account"]
+      account = credentials["account"] if credentials["account"]
+      carto_url = credentials["carto_url"] || "https://#{account}.carto.com"
       endpoint = Endpoint.new(options, credentials).get
-      con = Faraday.new(:url => "https://#{account}.carto.com") do |faraday|
+      con = Faraday.new(:url => carto_url) do |faraday|
         faraday.request  :multipart
         faraday.response :logger
         faraday.adapter  Faraday.default_adapter


### PR DESCRIPTION
Adds support for custom Carto instances. Now it's possible to configure `carto_url` into the credentials if needed.